### PR TITLE
Use pre increment instead of post increment

### DIFF
--- a/increment_version.sh
+++ b/increment_version.sh
@@ -33,20 +33,20 @@ fi
 
 if [ ! -z $major ]
 then
-  ((a[0]++))
+  ((++a[0]))
   a[1]=0
   a[2]=0
 fi
 
 if [ ! -z $minor ]
 then
-  ((a[1]++))
+  ((++a[1]))
   a[2]=0
 fi
 
 if [ ! -z $patch ]
 then
-  ((a[2]++))
+  ((++a[2]))
 fi
 
 echo "${a[0]}.${a[1]}.${a[2]}"


### PR DESCRIPTION
Avoid a non-zero return code when incrementing the version from a starting value of 0.

```
$ A=0; ((A++)); echo "ret: $?, A: $A"
ret: 1, A: 1
$ A=0; ((++A)); echo "ret: $?, A: $A"
ret: 0, A: 1
```